### PR TITLE
feature/s21_strtok

### DIFF
--- a/headers/s21_string.h
+++ b/headers/s21_string.h
@@ -48,6 +48,15 @@ s21_size_t s21_strlen(const char *str);
 char *s21_strpbrk(const char *str1, const char *str2);
 char *s21_strrchr(const char *str, int c);
 char *s21_strstr(const char *haystack, const char *needle);
+
+/**
+ * @brief extract tokens from strings
+ * @return The `s21_strtok()` function return a pointer to the next token, or `S21_NULL` if there are no more tokens.
+ *
+ * @version 8.0
+ * @date June 19, 2025
+ * @author Demian Domozhirov (DarkDomian | trelawnm at 21 School)
+ */
 char *s21_strtok(char *str, const char *delim);
 
 #endif

--- a/src/s21_strtok.c
+++ b/src/s21_strtok.c
@@ -5,14 +5,21 @@
 
 static char *olds;
 
-/* Return the length of the maximum initial segment
-   of S which contains only characters in ACCEPT.  */
-static s21_size_t s21_strspn(const char *s, const char *accept) {
+/**
+ * @brief get length of a prefix substring
+ * @return the `s21_strspn()` function returns the number of bytes in the
+ * initial segment of `str` which consist only of bytes from `accept`.
+ *
+ * @version 1.0
+ * @date June 19, 2025
+ * @author Demian Domozhirov (DarkDomian | trelawnm at 21 School)
+ */
+static s21_size_t s21_strspn(const char *str, const char *accept) {
   const char *p;
   const char *a;
   s21_size_t count = 0;
 
-  for (p = s; *p != '\0'; ++p) {
+  for (p = str; *p != '\0'; ++p) {
     for (a = accept; *a != '\0'; ++a)
       if (*p == *a) break;
     if (*a == '\0')
@@ -24,17 +31,7 @@ static s21_size_t s21_strspn(const char *s, const char *accept) {
   return count;
 }
 
-/* Parse S into tokens separated by characters in DELIM.
-   If S is NULL, the last string strtok() was called with is
-   used.  For example:
-        char s[] = "-abc-=-def";
-        x = strtok(s, "-");		// x = "abc"
-        x = strtok(NULL, "-=");		// x = "def"
-        x = strtok(NULL, "=");		// x = NULL
-                // s = "abc\0=-def\0"
-*/
-
-// TODO: add `s21_` prefix to `strpbrk` when it will be done
+// TODO: add `s21_` prefix to `strpbrk` and `strchr` when they will be done
 
 char *s21_strtok(char *str, const char *delim) {
   char *token;
@@ -48,7 +45,7 @@ char *s21_strtok(char *str, const char *delim) {
     return S21_NULL;
   }
 
-  /* Find the end of the token.  */
+  /* Find the end of the token. */
   token = str;
   str = strpbrk(token, delim);
   if (str == S21_NULL) /* This token finishes the string.  */

--- a/src/s21_strtok.c
+++ b/src/s21_strtok.c
@@ -1,3 +1,4 @@
+// TODO: remove <string.h> call from file
 #include <string.h>
 
 #include "../headers/s21_string.h"
@@ -23,39 +24,6 @@ static s21_size_t s21_strspn(const char *s, const char *accept) {
   return count;
 }
 
-/* Find the first occurrence in S of any character in ACCEPT.  */
-#if 0
-static char *s21_strpbrk(const char *s, const char *accept) {
-  while (*s != '\0') {
-    const char *a = accept;
-    while (*a != '\0')
-      if (*a++ == *s) return (char *)s;
-    ++s;
-  }
-
-  return S21_NULL;
-}
-#endif
-
-#if 0
-static char *s21_strpbrk(const char *s1, const char *s2) {
-  const char *c = s2;
-  if (!*s1) return (char *)S21_NULL;
-
-  while (*s1) {
-    for (c = s2; *c; c++) {
-      if (*s1 == *c) break;
-    }
-    if (*c) break;
-    s1++;
-  }
-
-  if (*c == '\0') s1 = S21_NULL;
-
-  return (char *)s1;
-}
-#endif
-
 /* Parse S into tokens separated by characters in DELIM.
    If S is NULL, the last string strtok() was called with is
    used.  For example:
@@ -65,6 +33,9 @@ static char *s21_strpbrk(const char *s1, const char *s2) {
         x = strtok(NULL, "=");		// x = NULL
                 // s = "abc\0=-def\0"
 */
+
+// TODO: add `s21_` prefix to `strpbrk` when it will be done
+
 char *s21_strtok(char *str, const char *delim) {
   char *token;
 

--- a/src/s21_strtok.c
+++ b/src/s21_strtok.c
@@ -1,0 +1,91 @@
+#include <string.h>
+
+#include "../headers/s21_string.h"
+
+static char *olds;
+
+/* Return the length of the maximum initial segment
+   of S which contains only characters in ACCEPT.  */
+static s21_size_t s21_strspn(const char *s, const char *accept) {
+  const char *p;
+  const char *a;
+  s21_size_t count = 0;
+
+  for (p = s; *p != '\0'; ++p) {
+    for (a = accept; *a != '\0'; ++a)
+      if (*p == *a) break;
+    if (*a == '\0')
+      return count;
+    else
+      ++count;
+  }
+
+  return count;
+}
+
+/* Find the first occurrence in S of any character in ACCEPT.  */
+#if 0
+static char *s21_strpbrk(const char *s, const char *accept) {
+  while (*s != '\0') {
+    const char *a = accept;
+    while (*a != '\0')
+      if (*a++ == *s) return (char *)s;
+    ++s;
+  }
+
+  return S21_NULL;
+}
+#endif
+
+#if 0
+static char *s21_strpbrk(const char *s1, const char *s2) {
+  const char *c = s2;
+  if (!*s1) return (char *)S21_NULL;
+
+  while (*s1) {
+    for (c = s2; *c; c++) {
+      if (*s1 == *c) break;
+    }
+    if (*c) break;
+    s1++;
+  }
+
+  if (*c == '\0') s1 = S21_NULL;
+
+  return (char *)s1;
+}
+#endif
+
+/* Parse S into tokens separated by characters in DELIM.
+   If S is NULL, the last string strtok() was called with is
+   used.  For example:
+        char s[] = "-abc-=-def";
+        x = strtok(s, "-");		// x = "abc"
+        x = strtok(NULL, "-=");		// x = "def"
+        x = strtok(NULL, "=");		// x = NULL
+                // s = "abc\0=-def\0"
+*/
+char *s21_strtok(char *str, const char *delim) {
+  char *token;
+
+  if (str == S21_NULL) str = olds;
+
+  /* Scan leading delimiters.  */
+  str += s21_strspn(str, delim);
+  if (*str == '\0') {
+    olds = str;
+    return S21_NULL;
+  }
+
+  /* Find the end of the token.  */
+  token = str;
+  str = strpbrk(token, delim);
+  if (str == S21_NULL) /* This token finishes the string.  */
+    olds = strchr(token, '\0');
+  else {
+    /* Terminate the token and make OLDS point past it.  */
+    *str = '\0';
+    olds = str + 1;
+  }
+  return token;
+}

--- a/tests/main.c
+++ b/tests/main.c
@@ -10,6 +10,8 @@ int main(void) {
   Suite *s = s21_strerror_suite();
   SRunner *sr = srunner_create(s);
 
+  srunner_add_suite(sr, s21_strtok_suite());
+
   // Check for CK_RUN_SUITE and set a custom log file
   const char *suite = getenv("CK_RUN_SUITE");
   if (suite && strlen(suite) > 0) {

--- a/tests/suites.h
+++ b/tests/suites.h
@@ -4,5 +4,6 @@
 #include <check.h>
 
 Suite *s21_strerror_suite(void);
+Suite *s21_strtok_suite(void);
 
 #endif /* SUITES_H */

--- a/tests/test_strtok.c
+++ b/tests/test_strtok.c
@@ -4,11 +4,11 @@
 #include "../headers/s21_string.h"
 #include "./suites.h"
 
-#define ALICE_TEXT                                                                 \
-  "Alice was beginning to get very tired of sitting by her sister on the "         \
-  "bank, and of having nothing to do: once or twice she had peeped into the "      \
-  "book her sister was reading, but it had no pictures or conversations in "       \
-  "it, “and what is the use of a book,” thought Alice “without pictures or " \
+#define ALICE_TEXT                                                            \
+  "Alice was beginning to get very tired of sitting by her sister on the "    \
+  "bank, and of having nothing to do: once or twice she had peeped into the " \
+  "book her sister was reading, but it had no pictures or conversations in "  \
+  "it, “and what is the use of a book,” thought Alice “without pictures or "  \
   "conversations?”"
 
 #define ALICE_SIZE 384

--- a/tests/test_strtok.c
+++ b/tests/test_strtok.c
@@ -15,7 +15,7 @@
 
 // Test 1: Basic tokenization with space delimiter
 START_TEST(test_strtok_space_delim) {
-  char buffer1[ALICE_SIZE], buffer2[ALICE_SIZE];
+  char buffer1[ALICE_SIZE] = {0}, buffer2[ALICE_SIZE] = {0};
   strcpy(buffer1, ALICE_TEXT);
   strcpy(buffer2, ALICE_TEXT);
 
@@ -27,7 +27,7 @@ START_TEST(test_strtok_space_delim) {
     ck_assert_mem_eq(buffer1, buffer2, ALICE_SIZE);
 
     token1 = strtok(NULL, " ");
-    token2 = s21_strtok(NULL, " ");
+    token2 = s21_strtok(S21_NULL, " ");
   }
 
   // Verify both return NULL at the end
@@ -38,7 +38,7 @@ END_TEST
 
 // Test 2: Comma and punctuation delimiters
 START_TEST(test_strtok_comma_delim) {
-  char buffer1[ALICE_SIZE], buffer2[ALICE_SIZE];
+  char buffer1[ALICE_SIZE] = {0}, buffer2[ALICE_SIZE] = {0};
   strcpy(buffer1, ALICE_TEXT);
   strcpy(buffer2, ALICE_TEXT);
 
@@ -50,14 +50,14 @@ START_TEST(test_strtok_comma_delim) {
     ck_assert_mem_eq(buffer1, buffer2, ALICE_SIZE);
 
     token1 = strtok(NULL, ",:”");
-    token2 = s21_strtok(NULL, ",:”");
+    token2 = s21_strtok(S21_NULL, ",:”");
   }
 }
 END_TEST
 
 // Test 3: Mixed delimiters with NULL calls
 START_TEST(test_strtok_mixed_delims_with_null) {
-  char buffer1[ALICE_SIZE], buffer2[ALICE_SIZE];
+  char buffer1[ALICE_SIZE] = {0}, buffer2[ALICE_SIZE] = {0};
   strcpy(buffer1, ALICE_TEXT);
   strcpy(buffer2, ALICE_TEXT);
 
@@ -73,7 +73,7 @@ START_TEST(test_strtok_mixed_delims_with_null) {
     // Every 3rd call, change delimiters
     const char *current_delims = ((iteration++) % 3 == 0) ? "h" : delims;
     token1 = strtok(NULL, current_delims);
-    token2 = s21_strtok(NULL, current_delims);
+    token2 = s21_strtok(S21_NULL, current_delims);
   }
 }
 END_TEST
@@ -81,7 +81,7 @@ END_TEST
 // Test 4: Edge case - empty string
 START_TEST(test_strtok_empty_string) {
   const char empty_str[] = "";
-  char buffer1[ALICE_SIZE], buffer2[ALICE_SIZE];
+  char buffer1[ALICE_SIZE] = {0}, buffer2[ALICE_SIZE] = {0};
   strcpy(buffer1, empty_str);
   strcpy(buffer2, empty_str);
 
@@ -97,7 +97,7 @@ END_TEST
 // Test 5: No delimiters found
 START_TEST(test_strtok_no_delims) {
   const char no_delims[] = "ThisStringHasNoDelimiters";
-  char buffer1[64], buffer2[64];
+  char buffer1[64] = {0}, buffer2[64] = {0};
   strcpy(buffer1, no_delims);
   strcpy(buffer2, no_delims);
 
@@ -108,7 +108,7 @@ START_TEST(test_strtok_no_delims) {
   ck_assert_mem_eq(buffer1, buffer2, strlen(no_delims) + 1);
 
   token1 = strtok(NULL, " ,.");
-  token2 = s21_strtok(NULL, " ,.");
+  token2 = s21_strtok(S21_NULL, " ,.");
   ck_assert_ptr_null(token1);
   ck_assert_ptr_null(token2);
 }

--- a/tests/test_strtok.c
+++ b/tests/test_strtok.c
@@ -1,128 +1,129 @@
-#include <string.h>
 #include <stdlib.h>
+#include <string.h>
 
-#include "./suites.h"
 #include "../headers/s21_string.h"
+#include "./suites.h"
 
-#define ALICE_TEXT "Alice was beginning to get very tired of sitting by her sister on the " \
-                   "bank, and of having nothing to do: once or twice she had peeped into the " \
-                   "book her sister was reading, but it had no pictures or conversations in " \
-                   "it, “and what is the use of a book,” thought Alice “without pictures or " \
-                   "conversations?”"
+#define ALICE_TEXT                                                                 \
+  "Alice was beginning to get very tired of sitting by her sister on the "         \
+  "bank, and of having nothing to do: once or twice she had peeped into the "      \
+  "book her sister was reading, but it had no pictures or conversations in "       \
+  "it, “and what is the use of a book,” thought Alice “without pictures or " \
+  "conversations?”"
 
 #define ALICE_SIZE 384
 
 // Test 1: Basic tokenization with space delimiter
 START_TEST(test_strtok_space_delim) {
-    char buffer1[ALICE_SIZE], buffer2[ALICE_SIZE];
-    strcpy(buffer1, ALICE_TEXT);
-    strcpy(buffer2, ALICE_TEXT);
+  char buffer1[ALICE_SIZE], buffer2[ALICE_SIZE];
+  strcpy(buffer1, ALICE_TEXT);
+  strcpy(buffer2, ALICE_TEXT);
 
-    char *token1 = strtok(buffer1, " ");
-    char *token2 = s21_strtok(buffer2, " ");
-    
-    while (token1 != NULL && token2 != NULL) {
-        ck_assert_str_eq(token1, token2);
-        ck_assert_mem_eq(buffer1, buffer2, ALICE_SIZE);
-        
-        token1 = strtok(NULL, " ");
-        token2 = s21_strtok(NULL, " ");
-    }
-    
-    // Verify both return NULL at the end
-    ck_assert_ptr_null(token1);
-    ck_assert_ptr_null(token2);
+  char *token1 = strtok(buffer1, " ");
+  char *token2 = s21_strtok(buffer2, " ");
+
+  while (token1 != NULL && token2 != NULL) {
+    ck_assert_str_eq(token1, token2);
+    ck_assert_mem_eq(buffer1, buffer2, ALICE_SIZE);
+
+    token1 = strtok(NULL, " ");
+    token2 = s21_strtok(NULL, " ");
+  }
+
+  // Verify both return NULL at the end
+  ck_assert_ptr_null(token1);
+  ck_assert_ptr_null(token2);
 }
 END_TEST
 
 // Test 2: Comma and punctuation delimiters
 START_TEST(test_strtok_comma_delim) {
-    char buffer1[ALICE_SIZE], buffer2[ALICE_SIZE];
-    strcpy(buffer1, ALICE_TEXT);
-    strcpy(buffer2, ALICE_TEXT);
+  char buffer1[ALICE_SIZE], buffer2[ALICE_SIZE];
+  strcpy(buffer1, ALICE_TEXT);
+  strcpy(buffer2, ALICE_TEXT);
 
-    char *token1 = strtok(buffer1, ",:”");
-    char *token2 = s21_strtok(buffer2, ",:”");
-    
-    while (token1 != NULL && token2 != NULL) {
-        ck_assert_str_eq(token1, token2);
-        ck_assert_mem_eq(buffer1, buffer2, ALICE_SIZE);
-        
-        token1 = strtok(NULL, ",:”");
-        token2 = s21_strtok(NULL, ",:”");
-    }
+  char *token1 = strtok(buffer1, ",:”");
+  char *token2 = s21_strtok(buffer2, ",:”");
+
+  while (token1 != NULL && token2 != NULL) {
+    ck_assert_str_eq(token1, token2);
+    ck_assert_mem_eq(buffer1, buffer2, ALICE_SIZE);
+
+    token1 = strtok(NULL, ",:”");
+    token2 = s21_strtok(NULL, ",:”");
+  }
 }
 END_TEST
 
 // Test 3: Mixed delimiters with NULL calls
 START_TEST(test_strtok_mixed_delims_with_null) {
-    char buffer1[ALICE_SIZE], buffer2[ALICE_SIZE];
-    strcpy(buffer1, ALICE_TEXT);
-    strcpy(buffer2, ALICE_TEXT);
+  char buffer1[ALICE_SIZE], buffer2[ALICE_SIZE];
+  strcpy(buffer1, ALICE_TEXT);
+  strcpy(buffer2, ALICE_TEXT);
 
-    const char *delims = " ,.:”";
-    char *token1 = strtok(buffer1, delims);
-    char *token2 = s21_strtok(buffer2, delims);
-    
-    int iteration = 0;
-    while (token1 != NULL && token2 != NULL) {
-        ck_assert_str_eq(token1, token2);
-        ck_assert_mem_eq(buffer1, buffer2, strlen(ALICE_TEXT) + 1);
-        
-        // Every 3rd call, change delimiters
-        const char *current_delims = ((iteration++) % 3 == 0) ? "h" : delims;
-        token1 = strtok(NULL, current_delims);
-        token2 = s21_strtok(NULL, current_delims);
-    }
+  const char *delims = " ,.:”";
+  char *token1 = strtok(buffer1, delims);
+  char *token2 = s21_strtok(buffer2, delims);
+
+  int iteration = 0;
+  while (token1 != NULL && token2 != NULL) {
+    ck_assert_str_eq(token1, token2);
+    ck_assert_mem_eq(buffer1, buffer2, strlen(ALICE_TEXT) + 1);
+
+    // Every 3rd call, change delimiters
+    const char *current_delims = ((iteration++) % 3 == 0) ? "h" : delims;
+    token1 = strtok(NULL, current_delims);
+    token2 = s21_strtok(NULL, current_delims);
+  }
 }
 END_TEST
 
 // Test 4: Edge case - empty string
 START_TEST(test_strtok_empty_string) {
-    char empty_str[] = "";
-    char buffer1[ALICE_SIZE], buffer2[ALICE_SIZE];
-    strcpy(buffer1, empty_str);
-    strcpy(buffer2, empty_str);
+  const char empty_str[] = "";
+  char buffer1[ALICE_SIZE], buffer2[ALICE_SIZE];
+  strcpy(buffer1, empty_str);
+  strcpy(buffer2, empty_str);
 
-    char *token1 = strtok(buffer1, " ");
-    char *token2 = s21_strtok(buffer2, " ");
-    
-    ck_assert_ptr_null(token1);
-    ck_assert_ptr_null(token2);
-    ck_assert_mem_eq(buffer1, buffer2, ALICE_SIZE);
+  char *token1 = strtok(buffer1, " ");
+  char *token2 = s21_strtok(buffer2, " ");
+
+  ck_assert_ptr_null(token1);
+  ck_assert_ptr_null(token2);
+  ck_assert_mem_eq(buffer1, buffer2, ALICE_SIZE);
 }
 END_TEST
 
 // Test 5: No delimiters found
 START_TEST(test_strtok_no_delims) {
-    char no_delims[] = "ThisStringHasNoDelimiters";
-    char buffer1[64], buffer2[64];
-    strcpy(buffer1, no_delims);
-    strcpy(buffer2, no_delims);
+  const char no_delims[] = "ThisStringHasNoDelimiters";
+  char buffer1[64], buffer2[64];
+  strcpy(buffer1, no_delims);
+  strcpy(buffer2, no_delims);
 
-    char *token1 = strtok(buffer1, " ,.");
-    char *token2 = s21_strtok(buffer2, " ,.");
-    
-    ck_assert_str_eq(token1, token2);
-    ck_assert_mem_eq(buffer1, buffer2, strlen(no_delims) + 1);
-    
-    token1 = strtok(NULL, " ,.");
-    token2 = s21_strtok(NULL, " ,.");
-    ck_assert_ptr_null(token1);
-    ck_assert_ptr_null(token2);
+  char *token1 = strtok(buffer1, " ,.");
+  char *token2 = s21_strtok(buffer2, " ,.");
+
+  ck_assert_str_eq(token1, token2);
+  ck_assert_mem_eq(buffer1, buffer2, strlen(no_delims) + 1);
+
+  token1 = strtok(NULL, " ,.");
+  token2 = s21_strtok(NULL, " ,.");
+  ck_assert_ptr_null(token1);
+  ck_assert_ptr_null(token2);
 }
 END_TEST
 
 Suite *s21_strtok_suite(void) {
-    Suite *s = suite_create("strtok");
-    TCase *tc = tcase_create("Core");
-    
-    tcase_add_test(tc, test_strtok_space_delim);
-    tcase_add_test(tc, test_strtok_comma_delim);
-    tcase_add_test(tc, test_strtok_mixed_delims_with_null);
-    tcase_add_test(tc, test_strtok_empty_string);
-    tcase_add_test(tc, test_strtok_no_delims);
-    
-    suite_add_tcase(s, tc);
-    return s;
+  Suite *s = suite_create("strtok");
+  TCase *tc = tcase_create("Core");
+
+  tcase_add_test(tc, test_strtok_space_delim);
+  tcase_add_test(tc, test_strtok_comma_delim);
+  tcase_add_test(tc, test_strtok_mixed_delims_with_null);
+  tcase_add_test(tc, test_strtok_empty_string);
+  tcase_add_test(tc, test_strtok_no_delims);
+
+  suite_add_tcase(s, tc);
+  return s;
 }

--- a/tests/test_strtok.c
+++ b/tests/test_strtok.c
@@ -1,0 +1,128 @@
+#include <string.h>
+#include <stdlib.h>
+
+#include "./suites.h"
+#include "../headers/s21_string.h"
+
+#define ALICE_TEXT "Alice was beginning to get very tired of sitting by her sister on the " \
+                   "bank, and of having nothing to do: once or twice she had peeped into the " \
+                   "book her sister was reading, but it had no pictures or conversations in " \
+                   "it, “and what is the use of a book,” thought Alice “without pictures or " \
+                   "conversations?”"
+
+#define ALICE_SIZE 384
+
+// Test 1: Basic tokenization with space delimiter
+START_TEST(test_strtok_space_delim) {
+    char buffer1[ALICE_SIZE], buffer2[ALICE_SIZE];
+    strcpy(buffer1, ALICE_TEXT);
+    strcpy(buffer2, ALICE_TEXT);
+
+    char *token1 = strtok(buffer1, " ");
+    char *token2 = s21_strtok(buffer2, " ");
+    
+    while (token1 != NULL && token2 != NULL) {
+        ck_assert_str_eq(token1, token2);
+        ck_assert_mem_eq(buffer1, buffer2, ALICE_SIZE);
+        
+        token1 = strtok(NULL, " ");
+        token2 = s21_strtok(NULL, " ");
+    }
+    
+    // Verify both return NULL at the end
+    ck_assert_ptr_null(token1);
+    ck_assert_ptr_null(token2);
+}
+END_TEST
+
+// Test 2: Comma and punctuation delimiters
+START_TEST(test_strtok_comma_delim) {
+    char buffer1[ALICE_SIZE], buffer2[ALICE_SIZE];
+    strcpy(buffer1, ALICE_TEXT);
+    strcpy(buffer2, ALICE_TEXT);
+
+    char *token1 = strtok(buffer1, ",:”");
+    char *token2 = s21_strtok(buffer2, ",:”");
+    
+    while (token1 != NULL && token2 != NULL) {
+        ck_assert_str_eq(token1, token2);
+        ck_assert_mem_eq(buffer1, buffer2, ALICE_SIZE);
+        
+        token1 = strtok(NULL, ",:”");
+        token2 = s21_strtok(NULL, ",:”");
+    }
+}
+END_TEST
+
+// Test 3: Mixed delimiters with NULL calls
+START_TEST(test_strtok_mixed_delims_with_null) {
+    char buffer1[ALICE_SIZE], buffer2[ALICE_SIZE];
+    strcpy(buffer1, ALICE_TEXT);
+    strcpy(buffer2, ALICE_TEXT);
+
+    const char *delims = " ,.:”";
+    char *token1 = strtok(buffer1, delims);
+    char *token2 = s21_strtok(buffer2, delims);
+    
+    int iteration = 0;
+    while (token1 != NULL && token2 != NULL) {
+        ck_assert_str_eq(token1, token2);
+        ck_assert_mem_eq(buffer1, buffer2, strlen(ALICE_TEXT) + 1);
+        
+        // Every 3rd call, change delimiters
+        const char *current_delims = ((iteration++) % 3 == 0) ? "h" : delims;
+        token1 = strtok(NULL, current_delims);
+        token2 = s21_strtok(NULL, current_delims);
+    }
+}
+END_TEST
+
+// Test 4: Edge case - empty string
+START_TEST(test_strtok_empty_string) {
+    char empty_str[] = "";
+    char buffer1[ALICE_SIZE], buffer2[ALICE_SIZE];
+    strcpy(buffer1, empty_str);
+    strcpy(buffer2, empty_str);
+
+    char *token1 = strtok(buffer1, " ");
+    char *token2 = s21_strtok(buffer2, " ");
+    
+    ck_assert_ptr_null(token1);
+    ck_assert_ptr_null(token2);
+    ck_assert_mem_eq(buffer1, buffer2, ALICE_SIZE);
+}
+END_TEST
+
+// Test 5: No delimiters found
+START_TEST(test_strtok_no_delims) {
+    char no_delims[] = "ThisStringHasNoDelimiters";
+    char buffer1[64], buffer2[64];
+    strcpy(buffer1, no_delims);
+    strcpy(buffer2, no_delims);
+
+    char *token1 = strtok(buffer1, " ,.");
+    char *token2 = s21_strtok(buffer2, " ,.");
+    
+    ck_assert_str_eq(token1, token2);
+    ck_assert_mem_eq(buffer1, buffer2, strlen(no_delims) + 1);
+    
+    token1 = strtok(NULL, " ,.");
+    token2 = s21_strtok(NULL, " ,.");
+    ck_assert_ptr_null(token1);
+    ck_assert_ptr_null(token2);
+}
+END_TEST
+
+Suite *s21_strtok_suite(void) {
+    Suite *s = suite_create("strtok");
+    TCase *tc = tcase_create("Core");
+    
+    tcase_add_test(tc, test_strtok_space_delim);
+    tcase_add_test(tc, test_strtok_comma_delim);
+    tcase_add_test(tc, test_strtok_mixed_delims_with_null);
+    tcase_add_test(tc, test_strtok_empty_string);
+    tcase_add_test(tc, test_strtok_no_delims);
+    
+    suite_add_tcase(s, tc);
+    return s;
+}


### PR DESCRIPTION
## Closed #32 | **Overview**  
This PR introduces the `s21_strtok()` function, a custom implementation of the standard `strtok()` function for the **string+** library. The function provides tokenization of strings using specified delimiters while maintaining compatibility with the original behavior.

## **Key Features**  
- [X] **Full compliance** with standard `strtok()` behavior:  
   - Supports sequential calls with `S21_NULL`  
   - Handles multiple delimiters  
   - Properly manages internal state between calls  

- [X] **Comprehensive test coverage** including:  
   - Basic tokenization (space delimiter)  
   - Complex delimiters (punctuation, mixed chars)  
   - Edge cases (empty string, no delimiters found)  

- [X] **Memory-safe** implementation with proper string termination    

## **Technical Details**  

### **Implementation Highlights**  
- Uses `s21_strspn()` for delimiter skipping  
- Leverages `strpbrk()` and `strchr()` (to be replaced with `s21_` versions later)  
- Maintains internal state via `static` variable `olds`  

### **Dependencies**  
- Requires `s21_strspn()` helper function (included)  
- Will eventually use `s21_strpbrk()` and `s21_strchr()` (marked as TODOs)  

## **Testing**  
### **Test Cases**  
1. **Basic Tokenization** (`test_strtok_space_delim`)  
2. **Complex Delimiters** (`test_strtok_comma_delim`)  
3. **Mixed Delimiters + NULL Calls** (`test_strtok_mixed_delims_with_null`)  
4. **Edge Cases** (`test_strtok_empty_string`, `test_strtok_no_delims`)  

### **How to Verify**  
```bash
make strtok.test
```
## Short describe of function's workflow:
signature: `char *s21_strtok(char *str, const char *delim)`
Parse `str` into tokens separated by characters in `delim`. If `str` is `S21_NULL`, the last string `strtok()` was called with is used. For example:
```cpp
    char s[] = "-abc-=-def";
    x = strtok(s, "-");		// x = "abc"
    x = strtok(NULL, "-=");		// x = "def"
    x = strtok(NULL, "=");		// x = NULL
            // s = "abc\0=-def\0"

```

Pay attention: that function rewrite existing string (that's why every test check memory too)