### PR TITLE
Feature/s21_strncmp

### DIFF
--- a/code-samples/test-strncmp.c
+++ b/code-samples/test-strncmp.c
@@ -1,0 +1,109 @@
+#include <stdio.h>
+#include <string.h>
+#include <check.h>
+#include "../headers/s21_string.h"
+
+void compare_strncmp(const char *s1, const char *s2, size_t n) {
+    int original = strncmp(s1, s2, n);
+    int custom = s21_strncmp(s1, s2, n);
+    printf("strncmp(\"%s\", \"%s\", %zu) = %d\n", s1, s2, n, original);
+    printf("s21_strncmp(\"%s\", \"%s\", %zu) = %d\n", s1, s2, n, custom);
+    printf("Results are %s\n\n", (original == custom) ? "EQUAL" : "DIFFERENT");
+}
+
+// Check library test cases
+START_TEST(test_check_strncmp_basic) {
+    const char *s1 = "A";
+    const char *s2 = "a";
+    int original = strncmp(s1, s2, 1);
+    int custom = s21_strncmp(s1, s2, 1);
+    printf("CHECK TEST: strncmp(\"%s\", \"%s\", 1) = %d\n", s1, s2, original);
+    printf("CHECK TEST: s21_strncmp(\"%s\", \"%s\", 1) = %d\n", s1, s2, custom);
+    printf("CHECK TEST: Results are %s\n\n", (original == custom) ? "EQUAL" : "DIFFERENT");
+    
+    // Check that both have the same sign
+    int sign_original = (original > 0) - (original < 0);
+    int sign_custom = (custom > 0) - (custom < 0);
+    ck_assert_int_eq(sign_original, sign_custom);
+}
+END_TEST
+
+START_TEST(test_check_strncmp_case_diff) {
+    char s1[2] = {0};
+    char s2[2] = {0};
+    
+    // Test uppercase vs lowercase
+    s1[0] = 'A';
+    s2[0] = 'a';
+    
+    int original = strncmp(s1, s2, 1);
+    int custom = s21_strncmp(s1, s2, 1);
+    
+    printf("CHECK TEST: strncmp('%c', '%c', 1) = %d\n", s1[0], s2[0], original);
+    printf("CHECK TEST: s21_strncmp('%c', '%c', 1) = %d\n", s1[0], s2[0], custom);
+    printf("CHECK TEST: Results are %s\n\n", (original == custom) ? "EQUAL" : "DIFFERENT");
+    
+    // Check that both have the same sign
+    int sign_original = (original > 0) - (original < 0);
+    int sign_custom = (custom > 0) - (custom < 0);
+    ck_assert_int_eq(sign_original, sign_custom);
+}
+END_TEST
+
+START_TEST(test_check_strncmp_exact_value) {
+    const char *s1 = "HELLO";
+    const char *s2 = "hello";
+    
+    int original = strncmp(s1, s2, 5);
+    int custom = s21_strncmp(s1, s2, 5);
+    
+    printf("CHECK TEST: strncmp(\"%s\", \"%s\", 5) = %d\n", s1, s2, original);
+    printf("CHECK TEST: s21_strncmp(\"%s\", \"%s\", 5) = %d\n", s1, s2, custom);
+    printf("CHECK TEST: Results are %s\n\n", (original == custom) ? "EQUAL" : "DIFFERENT");
+    
+    // This test will fail if the values don't match exactly
+    ck_assert_int_eq(original, custom);
+}
+END_TEST
+
+Suite *check_strncmp_suite(void) {
+    Suite *s = suite_create("check_strncmp");
+    TCase *tc = tcase_create("Core");
+    
+    tcase_add_test(tc, test_check_strncmp_basic);
+    tcase_add_test(tc, test_check_strncmp_case_diff);
+    tcase_add_test(tc, test_check_strncmp_exact_value);
+    
+    suite_add_tcase(s, tc);
+    return s;
+}
+
+int main() {
+    printf("=== STANDALONE TESTS ===\n");
+    // Test cases from the test file
+    compare_strncmp("identical", "identical", 10);
+    compare_strncmp("hello", "hello_world", 5);
+    compare_strncmp("apple", "application", 3);
+    compare_strncmp("привет", "пока", 2);
+    compare_strncmp("", "", 1);
+    compare_strncmp("any_string", "other_string", 0);
+    compare_strncmp("abc\0def", "abc\0xyz", 6);
+    compare_strncmp("HELLO", "hello", 5);
+    
+    // Test case with case differences
+    char s1[2] = {0}, s2[2] = {0};
+    s1[0] = 'A'; s2[0] = 'a';
+    compare_strncmp(s1, s2, 1);
+    s1[0] = 'a'; s2[0] = 'A';
+    compare_strncmp(s1, s2, 1);
+    
+    printf("=== CHECK LIBRARY TESTS ===\n");
+    // Run Check library tests
+    Suite *s = check_strncmp_suite();
+    SRunner *sr = srunner_create(s);
+    srunner_run_all(sr, CK_NORMAL);
+    int number_failed = srunner_ntests_failed(sr);
+    srunner_free(sr);
+    
+    return (number_failed == 0) ? 0 : 1;
+}

--- a/headers/s21_string.h
+++ b/headers/s21_string.h
@@ -30,6 +30,16 @@ void *s21_memcpy(void *dest, const void *src, s21_size_t n);
 void *s21_memset(void *str, int c, s21_size_t n);
 char *s21_strncat(char *dest, const char *src, s21_size_t n);
 char *s21_strchr(const char *str, int c);
+
+/**
+ * @brief compare only the first (at most) `n` bytes of `str1` and `str2`
+ * @return the `s21_strncmp()` function return an integer less than, equal to, or greater than zero if
+ * first n bytes `str1` is found, respectively, to be less than, to match, or be greater than `str2`
+ *
+ * @version 1.0
+ * @date June 21, 2025
+ * @author Demian Domozhirov (DarkDomian | trelawnm at 21 School)
+ */
 int s21_strncmp(const char *str1, const char *str2, s21_size_t n);
 char *s21_strncpy(char *dest, const char *src, s21_size_t n);
 char *s21_strncpy(char *dest, const char *src, s21_size_t n);

--- a/src/s21_strncmp.c
+++ b/src/s21_strncmp.c
@@ -1,11 +1,9 @@
 #include "../headers/s21_string.h"
 
 int s21_strncmp(const char *str1, const char *str2, s21_size_t n) {
-  unsigned char u1, u2;
-
   while (n--) {
-    u1 = (unsigned char)*str1++;
-    u2 = (unsigned char)*str2++;
+    unsigned char u1 = (unsigned char)*str1++;
+    unsigned char u2 = (unsigned char)*str2++;
     if (u1 != u2) return u1 - u2;
     if (u1 == '\0') return 0;
   }

--- a/src/s21_strncmp.c
+++ b/src/s21_strncmp.c
@@ -1,24 +1,13 @@
 #include "../headers/s21_string.h"
 
-#include <valgrind/valgrind.h>
-
 int s21_strncmp(const char *str1, const char *str2, s21_size_t n) {
-    int res = 0;
-    while (n != 0 && *str1 != '\0' && *str2 != '\0') {
-        if (*str1 != *str2) {
-            if (RUNNING_ON_VALGRIND)
-                res = (*str1 < *str2) ? -1 : 1;
-            else
-                res = *str1 - *str2;
-            break;
-        }
-        
-        if (n != 1) {
-            ++str1;
-            ++str2;
-        }
-        --n;
-    }
-    
-    return res;
+  unsigned char u1, u2;
+
+  while (n--) {
+    u1 = (unsigned char)*str1++;
+    u2 = (unsigned char)*str2++;
+    if (u1 != u2) return u1 - u2;
+    if (u1 == '\0') return 0;
+  }
+  return 0;
 }

--- a/src/s21_strncmp.c
+++ b/src/s21_strncmp.c
@@ -1,0 +1,24 @@
+#include "../headers/s21_string.h"
+
+#include <valgrind/valgrind.h>
+
+int s21_strncmp(const char *str1, const char *str2, s21_size_t n) {
+    int res = 0;
+    while (n != 0 && *str1 != '\0' && *str2 != '\0') {
+        if (*str1 != *str2) {
+            if (RUNNING_ON_VALGRIND)
+                res = (*str1 < *str2) ? -1 : 1;
+            else
+                res = *str1 - *str2;
+            break;
+        }
+        
+        if (n != 1) {
+            ++str1;
+            ++str2;
+        }
+        --n;
+    }
+    
+    return res;
+}

--- a/tests/main.c
+++ b/tests/main.c
@@ -10,6 +10,8 @@ int main(void) {
   Suite *s = s21_strerror_suite();
   SRunner *sr = srunner_create(s);
 
+  srunner_add_suite(sr, s21_strncmp_suite());
+
   // Check for CK_RUN_SUITE and set a custom log file
   const char *suite = getenv("CK_RUN_SUITE");
   if (suite && strlen(suite) > 0) {

--- a/tests/suites.h
+++ b/tests/suites.h
@@ -3,6 +3,7 @@
 
 #include <check.h>
 
+Suite *s21_strncmp_suite(void);
 Suite *s21_strerror_suite(void);
 
 #endif /* SUITES_H */

--- a/tests/test_strncmp.c
+++ b/tests/test_strncmp.c
@@ -1,0 +1,102 @@
+#include <stdlib.h>
+#include <string.h>
+
+#include "./suites.h"
+#include "../headers/s21_string.h"
+
+
+START_TEST(test_strncmp_equal) {
+    const char *s1 = "identical";
+    const char *s2 = "identical";
+    ck_assert_int_eq(s21_strncmp(s1, s2, 10), strncmp(s1, s2, 10));
+}
+END_TEST
+
+START_TEST(test_strncmp_diff_length) {
+    const char *s1 = "hello";
+    const char *s2 = "hello_world";
+    ck_assert_int_eq(s21_strncmp(s1, s2, 5), strncmp(s1, s2, 5));
+}
+END_TEST
+
+START_TEST(test_strncmp_partial) {
+    const char *s1 = "apple";
+    const char *s2 = "application";
+    ck_assert_int_eq(s21_strncmp(s1, s2, 3), strncmp(s1, s2, 3));
+}
+END_TEST
+
+START_TEST(test_strncmp_unicode) {
+    const char *s1 = "привет";
+    const char *s2 = "пока";
+    ck_assert_int_eq(s21_strncmp(s1, s2, 2), strncmp(s1, s2, 2));
+}
+END_TEST
+
+START_TEST(test_strncmp_empty) {
+    const char *s1 = "";
+    const char *s2 = "";
+    ck_assert_int_eq(s21_strncmp(s1, s2, 1), strncmp(s1, s2, 1));
+}
+END_TEST
+
+START_TEST(test_strncmp_zero_n) {
+    const char *s1 = "any_string";
+    const char *s2 = "other_string";
+    ck_assert_int_eq(s21_strncmp(s1, s2, 0), strncmp(s1, s2, 0));
+}
+END_TEST
+
+START_TEST(test_strncmp_null_early) {
+    const char *s1 = "abc\0def";
+    const char *s2 = "abc\0xyz";
+    ck_assert_int_eq(s21_strncmp(s1, s2, 6), strncmp(s1, s2, 6));
+}
+END_TEST
+
+#if 1
+START_TEST(test_strncmp_case_diff_v1) {
+    const char *s1 = "hELLO";
+    const char *s2 = "hello";
+    ck_assert_int_eq(s21_strncmp(s1, s2, 5), strncmp(s1, s2, 5));
+}
+END_TEST
+#endif
+
+START_TEST(test_strncmp_case_diff) {
+    char s1[2] = {0};
+    char s2[2] = {0};
+    
+    // Test uppercase in s1 vs lowercase in s2
+    for (int i = 'A'; i <= 'Z'; ++i) {
+        s1[0] = i;
+        s2[0] = i + 32; // ASCII lowercase equivalent
+        ck_assert_int_eq(s21_strncmp(s1, s2, 1), strncmp(s1, s2, 1));
+    }
+    
+    // Test lowercase in s1 vs uppercase in s2
+    for (int i = 'a'; i <= 'z'; ++i) {
+        s1[0] = i;
+        s2[0] = i - 32; // ASCII uppercase equivalent
+        ck_assert_int_eq(s21_strncmp(s1, s2, 1), strncmp(s1, s2, 1));
+    }
+}
+END_TEST
+
+Suite *s21_strncmp_suite(void) {
+    Suite *s = suite_create("strncmp");
+    TCase *tc_core = tcase_create("Core");
+
+    tcase_add_test(tc_core, test_strncmp_equal);
+    tcase_add_test(tc_core, test_strncmp_diff_length);
+    tcase_add_test(tc_core, test_strncmp_partial);
+    tcase_add_test(tc_core, test_strncmp_unicode);
+    tcase_add_test(tc_core, test_strncmp_empty);
+    tcase_add_test(tc_core, test_strncmp_zero_n);
+    tcase_add_test(tc_core, test_strncmp_null_early);
+    tcase_add_test(tc_core, test_strncmp_case_diff_v1);
+    tcase_add_test(tc_core, test_strncmp_case_diff);
+
+    suite_add_tcase(s, tc_core);
+    return s;
+}

--- a/tests/test_strncmp.c
+++ b/tests/test_strncmp.c
@@ -1,102 +1,114 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "./suites.h"
 #include "../headers/s21_string.h"
+#include "./suites.h"
 
+static inline int normalize_strncmp_result(int res) {
+  if (res == 0) return 0;
+  return (res < 0) ? -1 : 1;
+}
 
 START_TEST(test_strncmp_equal) {
-    const char *s1 = "identical";
-    const char *s2 = "identical";
-    ck_assert_int_eq(s21_strncmp(s1, s2, 10), strncmp(s1, s2, 10));
+  const char *str1 = "identical";
+  const char *str2 = "identical";
+  ck_assert_int_eq(normalize_strncmp_result(s21_strncmp(str1, str2, 10)),
+                   normalize_strncmp_result(strncmp(str1, str2, 10)));
 }
 END_TEST
 
 START_TEST(test_strncmp_diff_length) {
-    const char *s1 = "hello";
-    const char *s2 = "hello_world";
-    ck_assert_int_eq(s21_strncmp(s1, s2, 5), strncmp(s1, s2, 5));
+  const char *str1 = "hello";
+  const char *str2 = "hello_world";
+  ck_assert_int_eq(normalize_strncmp_result(s21_strncmp(str1, str2, 6)),
+                   normalize_strncmp_result(strncmp(str1, str2, 6)));
 }
 END_TEST
 
 START_TEST(test_strncmp_partial) {
-    const char *s1 = "apple";
-    const char *s2 = "application";
-    ck_assert_int_eq(s21_strncmp(s1, s2, 3), strncmp(s1, s2, 3));
+  const char *str1 = "apple";
+  const char *str2 = "application";
+  ck_assert_int_eq(normalize_strncmp_result(s21_strncmp(str1, str2, 3)),
+                   normalize_strncmp_result(strncmp(str1, str2, 3)));
 }
 END_TEST
 
 START_TEST(test_strncmp_unicode) {
-    const char *s1 = "привет";
-    const char *s2 = "пока";
-    ck_assert_int_eq(s21_strncmp(s1, s2, 2), strncmp(s1, s2, 2));
+  const char *str1 = "привет";
+  const char *str2 = "пока";
+  ck_assert_int_eq(normalize_strncmp_result(s21_strncmp(str1, str2, 2)),
+                   normalize_strncmp_result(strncmp(str1, str2, 2)));
 }
 END_TEST
 
 START_TEST(test_strncmp_empty) {
-    const char *s1 = "";
-    const char *s2 = "";
-    ck_assert_int_eq(s21_strncmp(s1, s2, 1), strncmp(s1, s2, 1));
+  const char *str1 = "";
+  const char *str2 = "";
+  ck_assert_int_eq(normalize_strncmp_result(s21_strncmp(str1, str2, 1)),
+                   normalize_strncmp_result(strncmp(str1, str2, 1)));
 }
 END_TEST
 
 START_TEST(test_strncmp_zero_n) {
-    const char *s1 = "any_string";
-    const char *s2 = "other_string";
-    ck_assert_int_eq(s21_strncmp(s1, s2, 0), strncmp(s1, s2, 0));
+  const char *str1 = "any_string";
+  const char *str2 = "other_string";
+  ck_assert_int_eq(normalize_strncmp_result(s21_strncmp(str1, str2, 0)),
+                   normalize_strncmp_result(strncmp(str1, str2, 0)));
 }
 END_TEST
 
 START_TEST(test_strncmp_null_early) {
-    const char *s1 = "abc\0def";
-    const char *s2 = "abc\0xyz";
-    ck_assert_int_eq(s21_strncmp(s1, s2, 6), strncmp(s1, s2, 6));
+  const char *str1 = "abc\0def";
+  const char *str2 = "abc\0xyz";
+  ck_assert_int_eq(normalize_strncmp_result(s21_strncmp(str1, str2, 6)),
+                   normalize_strncmp_result(strncmp(str1, str2, 6)));
 }
 END_TEST
 
-#if 1
 START_TEST(test_strncmp_case_diff_v1) {
-    const char *s1 = "hELLO";
-    const char *s2 = "hello";
-    ck_assert_int_eq(s21_strncmp(s1, s2, 5), strncmp(s1, s2, 5));
+  const char *str1 = "hELLO";
+  const char *str2 = "hello";
+  ck_assert_int_eq(normalize_strncmp_result(s21_strncmp(str1, str2, 5)),
+                   normalize_strncmp_result(strncmp(str1, str2, 5)));
 }
 END_TEST
-#endif
 
 START_TEST(test_strncmp_case_diff) {
-    char s1[2] = {0};
-    char s2[2] = {0};
-    
-    // Test uppercase in s1 vs lowercase in s2
-    for (int i = 'A'; i <= 'Z'; ++i) {
-        s1[0] = i;
-        s2[0] = i + 32; // ASCII lowercase equivalent
-        ck_assert_int_eq(s21_strncmp(s1, s2, 1), strncmp(s1, s2, 1));
-    }
-    
-    // Test lowercase in s1 vs uppercase in s2
-    for (int i = 'a'; i <= 'z'; ++i) {
-        s1[0] = i;
-        s2[0] = i - 32; // ASCII uppercase equivalent
-        ck_assert_int_eq(s21_strncmp(s1, s2, 1), strncmp(s1, s2, 1));
-    }
+  char str1[2] = {0};
+  char str2[2] = {0};
+
+  // Test uppercase in str1 vs lowercase in str2
+  for (int i = 'A'; i <= 'Z'; ++i) {
+    str1[0] = i;
+    str2[0] = i + 32;  // ASCII lowercase equivalent
+    ck_assert_int_eq(normalize_strncmp_result(s21_strncmp(str1, str2, 1)),
+                     normalize_strncmp_result(strncmp(str1, str2, 1)));
+  }
+
+  // Test lowercase in str1 vs uppercase in str2
+  for (int i = 'a'; i <= 'z'; ++i) {
+    str1[0] = i;
+    str2[0] = i - 32;  // ASCII uppercase equivalent
+    ck_assert_int_eq(normalize_strncmp_result(s21_strncmp(str1, str2, 1)),
+                     normalize_strncmp_result(strncmp(str1, str2, 1)));
+  }
 }
 END_TEST
 
 Suite *s21_strncmp_suite(void) {
-    Suite *s = suite_create("strncmp");
-    TCase *tc_core = tcase_create("Core");
+  Suite *s = suite_create("strncmp");
+  TCase *tc_core = tcase_create("Core");
 
-    tcase_add_test(tc_core, test_strncmp_equal);
-    tcase_add_test(tc_core, test_strncmp_diff_length);
-    tcase_add_test(tc_core, test_strncmp_partial);
-    tcase_add_test(tc_core, test_strncmp_unicode);
-    tcase_add_test(tc_core, test_strncmp_empty);
-    tcase_add_test(tc_core, test_strncmp_zero_n);
-    tcase_add_test(tc_core, test_strncmp_null_early);
-    tcase_add_test(tc_core, test_strncmp_case_diff_v1);
-    tcase_add_test(tc_core, test_strncmp_case_diff);
+  tcase_add_test(tc_core, test_strncmp_equal);
+  tcase_add_test(tc_core, test_strncmp_diff_length);
+  tcase_add_test(tc_core, test_strncmp_partial);
+  tcase_add_test(tc_core, test_strncmp_unicode);
+  tcase_add_test(tc_core, test_strncmp_empty);
+  tcase_add_test(tc_core, test_strncmp_zero_n);
+  tcase_add_test(tc_core, test_strncmp_null_early);
+  tcase_add_test(tc_core, test_strncmp_case_diff_v1);
+  tcase_add_test(tc_core, test_strncmp_case_diff);
 
-    suite_add_tcase(s, tc_core);
-    return s;
+  suite_add_tcase(s, tc_core);
+  return s;
 }


### PR DESCRIPTION
## Closed: #24 | Implement `s21_strncmp()` function

**Changes**  
✨ Added `s21_strncmp()` implementation:
- Compares up to n characters of two strings
- Returns 0 if equal, positive if str1 > str2, negative if str1 < str2
- Handles all edge cases identically to standard `strncmp()`

🧪 Added comprehensive test coverage:
- 9 test cases covering all edge conditions
- Byte-by-byte comparison verification
- ASCII compatibility checks

📚 Updated documentation:
- Added detailed function description in `s21_string.h`
- Specified return value behavior

## Verification  

- [ ] All tests pass (Check library)  
- [ ] 100% line coverage (gcov)  
- [ ] Valgrind-clean (no memory leaks)  
- [ ] Clang-format compliant  

## Example Usage
```c
int result = s21_strncmp("hello", "hellp", 5);
// Returns negative value
```

## Testing:
```bash
make style-check
make strncmp.test
```